### PR TITLE
Isolate service registration into the handler

### DIFF
--- a/api/src/handlers/items.rs
+++ b/api/src/handlers/items.rs
@@ -5,7 +5,7 @@ use actix_web::web::{HttpResponse, Json, Path};
 use actix_web::Result;
 
 pub fn index(conn: DbConnection) -> Result<Json<Vec<Item>>> {
-    Item::select(&conn).map(|items| Json(items)).map_err(|e| {
+    Item::select(&conn).map(Json).map_err(|e| {
         HttpResponse::InternalServerError()
             .body(e.to_string())
             .into()
@@ -13,19 +13,16 @@ pub fn index(conn: DbConnection) -> Result<Json<Vec<Item>>> {
 }
 
 pub fn create(conn: DbConnection, item: Json<NewItem>) -> Result<Json<Item>> {
-    item.into_inner()
-        .insert(&conn)
-        .map(|x| Json(x))
-        .map_err(|e| {
-            HttpResponse::InternalServerError()
-                .body(e.to_string())
-                .into()
-        })
+    item.into_inner().insert(&conn).map(Json).map_err(|e| {
+        HttpResponse::InternalServerError()
+            .body(e.to_string())
+            .into()
+    })
 }
 
 pub fn show(item_id: Path<i32>, conn: DbConnection) -> Result<Json<Item>> {
     Item::find(item_id.into_inner(), &conn)
-        .map(|item| Json(item))
+        .map(Json)
         .map_err(|e| {
             match e {
                 diesel::result::Error::NotFound => HttpResponse::NotFound().finish(),
@@ -49,7 +46,7 @@ pub fn destroy(item_id: Path<i32>, conn: DbConnection) -> Result<()> {
 
 pub fn update(item_id: Path<i32>, conn: DbConnection, item: Json<ItemForm>) -> Result<Json<Item>> {
     Item::update(item_id.into_inner(), item.into_inner(), &conn)
-        .map(|item| Json(item))
+        .map(Json)
         .map_err(|e| {
             match e {
                 diesel::result::Error::NotFound => HttpResponse::NotFound().finish(),

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate diesel;
-extern crate env_logger;
 
-use actix_web::web;
 use actix_web::middleware::Logger;
 use actix_web::{App, HttpServer};
 
@@ -20,17 +18,7 @@ fn main() -> io::Result<()> {
         let pool = db::init_pool(db_url).expect("Couldn't establish connection to database!");
         App::new()
             .data(pool)
-            .service(
-                web::resource("/api/items")
-                    .route(web::get().to(handlers::items::index))
-                    .route(web::post().to(handlers::items::create)),
-            )
-            .service(
-                web::resource("/api/items/{item_id}")
-                    .route(web::get().to(handlers::items::show))
-                    .route(web::delete().to(handlers::items::destroy))
-                    .route(web::patch().to(handlers::items::update)),
-            )
+            .service(handlers::items::handler(&"/api/items"))
             .wrap(Logger::default())
     })
     .bind("0.0.0.0:3014")?

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -13,11 +13,12 @@ mod handlers;
 fn main() -> io::Result<()> {
     env_logger::init();
 
-    HttpServer::new(|| {
-        let db_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-        let pool = db::init_pool(db_url).expect("Couldn't establish connection to database!");
+    let db_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let pool = db::init_pool(db_url).expect("Couldn't establish connection to database!");
+
+    HttpServer::new(move || {
         App::new()
-            .data(pool)
+            .data(pool.clone())
             .service(handlers::items::handler(&"/api/items"))
             .wrap(Logger::default())
     })


### PR DESCRIPTION
This change removes the "pub" from all the actual handlers and provides a single public handler function.

The second commit just silences "cargo clippy".
