### PR TITLE
create db pool outside of server closure

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -15,11 +15,12 @@ mod handlers;
 fn main() -> io::Result<()> {
     env_logger::init();
 
-    HttpServer::new(|| {
-        let db_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-        let pool = db::init_pool(db_url).expect("Couldn't establish connection to database!");
+    let db_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let pool = db::init_pool(db_url).expect("Couldn't establish connection to database!");
+
+    HttpServer::new(move || {
         App::new()
-            .data(pool)
+            .data(pool.clone())
             .service(
                 web::resource("/api/items")
                     .route(web::get().to(handlers::items::index))


### PR DESCRIPTION
This way you get a better error message when pool creation fails. This is also how it is done in the actix-web diesel example here:
https://github.com/actix/examples/blob/master/diesel/src/main.rs#L124
